### PR TITLE
Fix exception when user_inputs contains unicode characters

### DIFF
--- a/tests/zxcvbn_test.py
+++ b/tests/zxcvbn_test.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from zxcvbn import zxcvbn
+
+
+def test_unicode_user_inputs():
+    # test Issue #12 -- don't raise a UnicodeError with unicode user_inputs or
+    # passwords.
+    input_ = u'Фамилия'
+    password = u'pÄssword junkiË'
+
+    zxcvbn(password, user_inputs=[input_])
+
+
+def test_invalid_user_inputs():
+    # don't raise an error with non-string types for user_inputs
+    input_ = None
+    password = u'pÄssword junkiË'
+
+    zxcvbn(password, user_inputs=[input_])

--- a/zxcvbn/__init__.py
+++ b/zxcvbn/__init__.py
@@ -4,12 +4,24 @@ from . import matching, scoring, time_estimates, feedback
 
 
 def zxcvbn(password, user_inputs=None):
+    try:
+        # Python 2 string types
+        basestring = (str, unicode)
+    except NameError:
+        # Python 3 string types
+        basestring = (str, bytes)
+
     if user_inputs is None:
         user_inputs = []
 
     start = datetime.now()
 
-    sanitized_inputs = [str(arg).lower() for arg in user_inputs]
+    sanitized_inputs = []
+    for arg in user_inputs:
+        if not isinstance(arg, basestring):
+            arg = str(arg)
+        sanitized_inputs.append(arg.lower())
+
     matching.set_user_input_dictionary(sanitized_inputs)
 
     matches = matching.omnimatch(password)


### PR DESCRIPTION
zxcvbn shouldn't fail when the user inputs are unicode. This encodes strings as
utf-8 rather than ascii.

fixes: #12