### PR TITLE
Add Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,19 @@ setup(
     description='Python implementation of Dropbox\'s realistic password '
                 'strength estimator, zxcvbn',
     keywords=['zxcvbn', 'password', 'security'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Security',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ]
 )


### PR DESCRIPTION
Provide project metadata via Trove classifiers. References:

- http://www.python.org/dev/peps/pep-0301/#distutils-trove-classification
- http://www.catb.org/~esr/trove/