### PR TITLE
rename to zxcvbn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 |Build Status|
 
-zxcvbn-python
-=============
+zxcvbn
+======
 
 A realistic password strength estimator.
 
@@ -25,7 +25,7 @@ Features
 Installation
 ------------
 
-Install the package using pip: ``pip install zxcvbn-python``
+Install the package using pip: ``pip install zxcvbn``
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst') as file:
     long_description = file.read()
 
 setup(
-    name='zxcvbn-python',
+    name='zxcvbn',
     version='4.4.22',
     packages=['zxcvbn'],
     url='https://github.com/dwolfhub/zxcvbn-python',


### PR DESCRIPTION
Now that @dwolfhub has access to https://pypi.python.org/pypi/zxcvbn update the setup.py and docs to point to that version.