### PR TITLE
Fix bad syntax in setup.py (missing comma).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst') as file:
     long_description = file.read()
 
 setup(
-    name='zxcvbn'
+    name='zxcvbn',
     version='4.4.24',
     packages=['zxcvbn'],
     url='https://github.com/dwolfhub/zxcvbn-python',


### PR DESCRIPTION
Fix a trivial error from commit 94f20074425c894c59a9df4e7f2de0f2c016266a