### PR TITLE
Add the license file to the source tarball

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,9 +1,0 @@
-README.rst
-setup.py
-zxcvbn/__init__.py
-zxcvbn/adjacency_graphs.py
-zxcvbn/feedback.py
-zxcvbn/frequency_lists.py
-zxcvbn/matching.py
-zxcvbn/scoring.py
-zxcvbn/time_estimates.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
The license file is required by some embedded Linux distribution
tools (e.g. Yocto) to perform their license compliance check.

This patch renames MANIFEST to MANIFEST.in and adds the LICENSE.txt
file to it. It also removes all other files from MANIFEST.in since
they are automatically included.

Fixes issue #54.

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>